### PR TITLE
fix(#14): if rust projectName contains hyphens, replace them with `_`

### DIFF
--- a/internal/helpers/constants.go
+++ b/internal/helpers/constants.go
@@ -1,5 +1,6 @@
 package helpers
 
-const TEMPLATES_FILES_CONFIG="template-files.json"
+const TEMPLATES_FILES_CONFIG = "template-files.json"
 const PROJECT_NAME = "projectName"
+const PROJECT_NAME_WITH_REPLACED_HYPHENS = "projectNameReplacedHyphens"
 const GO_PACKAGE_NAME = "packageName"

--- a/internal/templates/types.go
+++ b/internal/templates/types.go
@@ -78,6 +78,7 @@ func GetTemplate(templateName string, projectName string, stringOptions string) 
 			BuildTool:    cli.Npm,
 		}, nil
 	case "rust":
+		templateOptions[helpers.PROJECT_NAME_WITH_REPLACED_HYPHENS] = strings.ReplaceAll(projectName, "-", "_")
 		return &Template{
 			Name:         "rust",
 			TemplateData: templateOptions,


### PR DESCRIPTION
… for all import statements in all *.rs files