### PR TITLE
Add ability to use local templates repository to fetch templates during development

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@
   then this will create go module with name `packageName\project_name`.  
    i.e. if you use options `-t go -n my-app -o packageName=github.com/csd1100`
   the project module name will be `github.com/csd1100/my-app`
+
+## For developers
+
+- If Following environment variables are set local templates can be used:
+
+```sh
+export DEV=true
+export INIT_DEV_REPO_PATH=`<local path to the templates repo>`
+export INIT_DEV_BRANCH_NAME=`<name of the branch to pull>`
+```
+
+- Using only `INIT_DEV_BRANCH_NAME` will use branch from
+  https://github.com/csd1100/templates repository.

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/csd1100/init/internal/cli"
 	"github.com/csd1100/init/internal/helpers"
@@ -94,8 +95,31 @@ func createTempDirAndChangeCWD() (*string, error) {
 }
 
 func cloneTemplateRepoAndChangeCWD(options utils.Options) error {
-	err := cli.Git.CloneSingleBranch("https://github.com/csd1100/templates/",
-		options.Template.(*templates.Template).Name)
+	repo := "https://github.com/csd1100/templates/"
+	branch := options.Template.(*templates.Template).Name
+
+	if dev, isPresent := os.LookupEnv(helpers.DEV); isPresent && dev == "true" {
+		if repo_path, isPresent := os.LookupEnv(helpers.INIT_DEV_REPO_PATH); isPresent {
+			repo_abs_path, err := filepath.Abs(repo_path)
+			if err != nil {
+				helpers.AppLogger.Error("Invalid Git Repository Path: %s set for %s",
+					repo_path, helpers.INIT_DEV_REPO_PATH)
+			} else {
+				helpers.AppLogger.Info("Using Local Git Repository: %s", repo_abs_path)
+				if strings.HasSuffix(repo_abs_path, ".git") {
+					repo = fmt.Sprintf("file://%s", repo_abs_path)
+				} else {
+					repo = fmt.Sprintf("file://%s.git", repo_abs_path)
+				}
+			}
+		}
+		if branch_name, isPresent := os.LookupEnv(helpers.INIT_DEV_BRANCH_NAME); isPresent {
+			helpers.AppLogger.Info("Using Git Branch: %s from %s Repository", branch_name, repo)
+			branch = branch_name
+		}
+	}
+
+	err := cli.Git.CloneSingleBranch(repo, branch)
 
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/internal/helpers/constants.go
+++ b/internal/helpers/constants.go
@@ -4,3 +4,7 @@ const TEMPLATES_FILES_CONFIG = "template-files.json"
 const PROJECT_NAME = "projectName"
 const PROJECT_NAME_WITH_REPLACED_HYPHENS = "projectNameReplacedHyphens"
 const GO_PACKAGE_NAME = "packageName"
+
+const DEV = "DEV"
+const INIT_DEV_REPO_PATH = "INIT_DEV_REPO_PATH"
+const INIT_DEV_BRANCH_NAME = "INIT_DEV_BRANCH_NAME"


### PR DESCRIPTION
- If Following environment variables are set local templates can be used:

```sh
export DEV=true
export INIT_DEV_REPO_PATH=`<local path to the templates repo>`
export INIT_DEV_BRANCH_NAME=`<name of the branch to pull>`
```

- Using only `INIT_DEV_BRANCH_NAME` will use branch from
  https://github.com/csd1100/templates repository.